### PR TITLE
SupabaseProvider: add children to Props

### DIFF
--- a/src/SupabaseProvider.tsx
+++ b/src/SupabaseProvider.tsx
@@ -1,11 +1,12 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { Component } from 'solid-js'
+import type { Component, JSX } from 'solid-js'
 import { createContext } from 'solid-js'
 
 export const SupabaseContext = createContext<SupabaseClient>()
 
 interface Props {
   client: SupabaseClient
+  children?: JSX.Element
 }
 
 export const SupabaseProvider: Component<Props> = (props) => {


### PR DESCRIPTION
Solid.js 1.4 removes default `children` property from `Component`. This PR includes this property in `Props` to help TypeScript type checking.